### PR TITLE
fix npm import path

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vue-property-decorator",
   "version": "5.0.0",
   "description": "property decorators for Vue Component",
-  "main": "src/vue-property-decorator.js",
+  "main": "lib/vue-property-decorator.js",
   "keywords": [
     "vue",
     "typescript",


### PR DESCRIPTION
src/ doesn't exist in the npm publish, so 5.0.0 breaks all import vue-property-decorator statements