### PR TITLE
Please also export Vue

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ There are 6 decorators:
 * `@Component` (`export Component from 'vue-class-component'`)
 
 ```typescript
-import Vue from 'vue'
-import { Component, Inject, Model, Prop, Watch } from 'vue-property-decorator'
+import { Component, Inject, Model, Prop, Vue, Watch } from 'vue-property-decorator'
 
 const s = Symbol('baz')
 

--- a/src/vue-property-decorator.ts
+++ b/src/vue-property-decorator.ts
@@ -90,4 +90,4 @@ export function Watch(path: string, options: WatchOptions = {}): MethodDecorator
   })
 }
 
-export { Component }
+export { Component, Vue }


### PR DESCRIPTION
This way we can get rid of the `allowSyntheticDefaultImports` option and reduce our import to a single statement:

```js
import { Component, Prop, Vue} from 'vue-property-decorator'

@Component
export default class MyComponent extends Vue {
  @Prop()
  name: string
}
```