### PR TITLE
model as prop

### DIFF
--- a/src/vue-property-decorator.ts
+++ b/src/vue-property-decorator.ts
@@ -51,10 +51,16 @@ export function Provide(key?: string | symbol): PropertyDecorator {
  * @param  event event name
  * @return PropertyDecorator
  */
-export function Model(event?: string): PropertyDecorator {
-  return createDecorator((componentOptions, prop) => {
-    componentOptions.model = { prop, event: event || prop }
-  })
+export function Model(event?: string, options: (PropOptions | Constructor[] | Constructor) = {}): PropertyDecorator {
+  return function (target: Vue, key: string) {
+    if (!Array.isArray(options) && typeof (options as PropOptions).type === 'undefined') {
+      (options as PropOptions).type = Reflect.getMetadata('design:type', target, key)
+    }
+    createDecorator((componentOptions, k) => {
+      (componentOptions.props || (componentOptions.props = {}) as any)[k] = options;
+    	componentOptions.model = { prop: k, event: event || k }
+    })(target, key)
+  }
 }
 
 /**

--- a/test/decorator.spec.ts
+++ b/test/decorator.spec.ts
@@ -46,7 +46,8 @@ test('@Model decorator test', t => {
   }
 
   const { $options } = new Test()
-  t.deepEqual($options.model, { prop: 'checked', event: 'change' })
+	t.deepEqual($options.model, { prop: 'checked', event: 'change' })
+	t.deepEqual($options.props, { checked: { type: Boolean } })
 })
 
 test('@Prop decorator test', t => {


### PR DESCRIPTION
The `@Model` decorator adds the information about which property is used for `v-model`.
In the specifications, we also have to declare the property for it to be given to the component.

If my component is written like this :
```
  ...
  @Model('input')
  value
  ...
```
When the component changes the value, the event is emitted and the parent bound data is changed. Now, if the parent bound data changed, the component' `value` won't change : because `value` is not a propriety.

For it to work as expected (for the binding parent->component to be effective) we also have to declare the property like this : 
```
  ...
  @Model('input')
  @Prop()
  value
  ...
```

Because `@Model` always demands a `@Prop`, I propose here to add to the `@Model` decorator the declaration as a property, for it is counter-intuitive to write `@Model() @Prop()`, and the dysfunctionment when we forget `@Prop` is not straightforward to understand, and for it is quite redundant to be compelled to write `@Prop()` after each `@Model` declaration.

Note: the modification is backward compatible as `@Model(xxx) @Prop()` will give the same result as `@Model(xxx)`