### PR TITLE
Add template typing

### DIFF
--- a/src/template.d.ts
+++ b/src/template.d.ts
@@ -1,0 +1,9 @@
+declare module '*.html' {
+    import Vue = require('vue')
+    interface Template {
+      <V extends Vue>(options: Vue.ComponentOptions<V>): Vue.ComponentOptions<V>
+      <V extends typeof Vue>(component: V): V
+    }
+    const template: Template
+    export = template
+  }


### PR DESCRIPTION
Not sure if you want to add this to your repo, but I'm adding it to all my projects where I use vue-property-decorator
```
import { Component, Vue } from 'vue-property-decorator';
import Template from './app.component.html';

@Template
@Component
export default class AppComponent extends Vue {
}
```
inspired in https://github.com/ktsn/vue-template-loader#typescript