### PR TITLE
Named export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ src/*.js
 test/*.spec.js
 package-lock.json
 .vscode/setting.json
+.idea

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,8 +1,10 @@
 export default {
-  entry: 'lib/vue-property-decorator.js',
-  format: 'umd',
-  moduleName: 'VuePropertyDecorator',
-  dest: 'lib/vue-property-decorator.umd.js',
+  input: 'lib/vue-property-decorator.js',
+  name: 'VuePropertyDecorator',
+  output: {
+    file: 'lib/vue-property-decorator.umd.js',
+    format: 'umd'
+  },
   external: [
     'vue', 'vue-class-component', 'reflect-metadata'
   ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,6 +6,8 @@ export default {
   external: [
     'vue', 'vue-class-component', 'reflect-metadata'
   ],
+  exports: 'named',
+  name: 'vue-property-decorator',
   globals: {
     'vue': 'Vue',
     'vue-class-component': 'VueClassComponent'

--- a/src/vue-property-decorator.ts
+++ b/src/vue-property-decorator.ts
@@ -158,7 +158,10 @@ export function On(event?: string): MethodDecorator {
     const original=componentOptions.created;
     (componentOptions as any).created=function(){
       original();
-      this.$on(event||key, componentOptions.methods[k]);
+      if (typeof componentOptions.methods !== 'undefined') {
+        this.$on(event||key, componentOptions.methods[k]);
+      }
+
     };
   });
 }
@@ -175,18 +178,20 @@ export function Once(event?: string): MethodDecorator {
     }
     const original=componentOptions.created;
     (componentOptions as any).created=function(){
-      original();
-      this.$once(event||key, componentOptions.methods[k]);
+      original()
+      if (typeof componentOptions.methods !== 'undefined') {
+        this.$once(event || key, componentOptions.methods[k]);
+      }
     };
   });
 }
 
 /**
  * decorator of $nextTick
- * 
+ *
  * @export
- * @param {string} method 
- * @returns {MethodDecorator} 
+ * @param {string} method
+ * @returns {MethodDecorator}
  */
 export function NextTick(method: string): MethodDecorator {
   return function (target: Vue, key: string, descriptor: any) {


### PR DESCRIPTION
This PR resolve following error with rollup

```
[10:39:37] Error in plugin 'gulp-rollup'
Message:
    'Component' is not exported by node_modules\vue-property-decorator\lib\vue-property-decorator.umd.js
Details:
    code: MISSING_EXPORT
    url: https://github.com/rollup/rollup/wiki/Troubleshooting#name-is-not-exported-by-module
    pos: 1241
    loc: [object Object]
    frame: 19:  import { Component } from 'vue-property-decorator';
21: import { Component } from 'vue-property-decorator';
             ^
```

Before this PR is should manually define named export for rollup

```js
rollup({
plugins: [
      cjs({
        namedExports: {
           'vue-property-decorator': [ 'Component' ]
        }
      })
    ]
})
```