### PR TITLE
Don't put props on @Model attributes

### DIFF
--- a/src/vue-property-decorator.ts
+++ b/src/vue-property-decorator.ts
@@ -59,7 +59,6 @@ export function Model(event?: string, options: (PropOptions | Constructor[] | Co
       (options as PropOptions).type = Reflect.getMetadata('design:type', target, key)
     }
     createDecorator((componentOptions, k) => {
-      (componentOptions.props || (componentOptions.props = {}) as any)[k] = options
       componentOptions.model = { prop: k, event: event || k }
     })(target, key)
   }


### PR DESCRIPTION
This breaks them as far as I can see. See: https://github.com/kaorun343/vue-property-decorator/issues/70

This means the options go nowhere. What options would one pass? There's nothing documented.