### PR TITLE
Update Vue Class Component dependency to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "typings": "./lib/vue-property-decorator.d.ts",
   "dependencies": {
-    "vue-class-component": "^6.2.0"
+    "vue-class-component": "^7.0.1"
   },
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5346,9 +5346,10 @@ vm-browserify@0.0.4:
   dependencies:
     indexof "0.0.1"
 
-vue-class-component@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/vue-class-component/-/vue-class-component-6.2.0.tgz#7adb1daa9a868c75f30f97f33f4f1b94aee62089"
+vue-class-component@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/vue-class-component/-/vue-class-component-7.0.1.tgz#7af2225c600667c7042b60712eefdf41dfc6de63"
+  integrity sha512-YIihdl7YmceEOjSwcxLhCXCNA3TKC2FStuMcjtuzhUAgw5x5d1T5gZTmVQHGyOaQsaKffL4GlZzYN3dlMYl53w==
 
 vue@^2.5.3:
   version "2.5.16"


### PR DESCRIPTION
updates the dependency of Vue Class Component to get a few bug fixes from upstream. There are no breaking changes between 6.2.0 -> 7.0.1 (https://github.com/vuejs/vue-class-component/releases)