### PR TITLE
fix @Emit return value to make it transparent

### DIFF
--- a/src/vue-property-decorator.ts
+++ b/src/vue-property-decorator.ts
@@ -143,6 +143,8 @@ export function Emit(event?: string): MethodDecorator {
       } else {
         emit(returnValue)
       }
+
+      return returnValue
     }
   }
 }


### PR DESCRIPTION
`@Emit` decorator is handling the decorated function's promise but not returning it. This causes issues like not being able to get the result calling the decorated method or the prevention of a right exception propagation. One example of the latest is demonstrated [in this fiddle](https://jsfiddle.net/tjch2b3s/).

Returning the promise or value we let another functions and decorators to handle it.