### PR TITLE
Add @PropSync decorator to more easier handle .sync modifier on props

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ There are 7 decorators and 1 function (Mixin):
 * [`@Inject`](#Provide)
 * [`@Model`](#Model)
 * [`@Prop`](#Prop)
+* [`@PropSync`](#PropSync)
 * [`@Provide`](#Provide)
 * [`@Watch`](#Watch)
 * `@Component` (**provided by** [vue-class-component](https://github.com/vuejs/vue-class-component))
@@ -69,6 +70,41 @@ export default {
 ## Each prop's default value need to be defined as same as the example code shown in above.
 
 It's **not** supported to define each `default` property like `@Prop() prop = 'default value'` .
+
+### <a id="PropSync"></a> `@PropSync(propName: string, options: (PropOptions | Constructor[] | Constructor) = {})` decorator
+
+```ts
+import { Vue, Component, Prop } from 'vue-property-decorator'
+
+@Component
+export default class YourComponent extends Vue {
+  @Prop('name', { type: String }) syncedName!: string
+}
+```
+
+is equivalent to
+
+```js
+export default {
+  props: {
+    name: {
+      type: String
+    },
+  },
+  computed: {
+    syncedName: {
+      get() {
+        return this.name
+      },
+      set(value) {
+        this.$emit('update:name', value)
+      }
+    }
+  }
+}
+```
+
+Other than that it works just like [`@Prop`](#Prop) other than it takes the propName as an argument of the decorator, in addition to it creates a computed getter and setter behind the scenes. This way you can interface with the property as it was a regular data property whilst making it as easy as appending the `.sync` modifier in the parent component.
 
 ### <a id="Model"></a> `@Model(event?: string, options: (PropOptions | Constructor[] | Constructor) = {})` decorator
 

--- a/src/vue-property-decorator.ts
+++ b/src/vue-property-decorator.ts
@@ -90,6 +90,32 @@ export function Prop(options: (PropOptions | Constructor[] | Constructor) = {}):
 }
 
 /**
+ * decorator of a synced prop
+ * @param propName the name to interface with from outside, must be different from decorated property
+ * @param options the options for the synced prop
+ * @return PropertyDecorator | void
+ */
+export function PropSync(propName: string, options: (PropOptions | Constructor[] | Constructor) = {}): PropertyDecorator {
+  // @ts-ignore
+  return (target: Vue, key: string) => {
+    applyMetadata(options, target, key)
+    createDecorator((componentOptions, k) => {
+      (componentOptions.props || (componentOptions.props = {} as any))[propName] = options
+      ;(componentOptions.computed || (componentOptions.computed = {}))[k] = {
+        get() {
+          return this[propName]
+        },
+        set(value) {
+          // @ts-ignore
+          this.$emit(`update:${propName}`, value)
+        }
+      }
+    })(target, key)
+  }
+}
+
+
+/**
  * decorator of a watch function
  * @param  path the path or the expression to observe
  * @param  WatchOption


### PR DESCRIPTION
It works just like @Prop other than it takes the propName as an argument of the decorator, in addition to it creates a computed getter and setter behind the scenes. This way you can interface with the property as it was a regular data property whilst making it as easy as appending the .sync modifier in the parent component.

I have created tests and written some documentation for the feature, but please come with some feedback or questions if anything is unclear or seems funky.