### PR TITLE
Add @ProvideReactive and @InjectReactive decorators

### DIFF
--- a/src/vue-property-decorator.ts
+++ b/src/vue-property-decorator.ts
@@ -87,6 +87,7 @@ export function ProvideReactive(key?: string | symbol): PropertyDecorator {
         let rv = Object.create((typeof original === 'function' ? original.call(this) : original) || null)
         rv[reactiveInjectKey] = {}
         for (let i in provide.managed) {
+          rv[provide.managed[i]] = this[i] // Duplicates the behavior of `@Provide`
           Object.defineProperty(rv[reactiveInjectKey], provide.managed[i], {
             enumerable: true,
             get: () => this[i]

--- a/src/vue-property-decorator.ts
+++ b/src/vue-property-decorator.ts
@@ -47,7 +47,7 @@ export function InjectReactive(options?: { from?: InjectKey, default?: any } | I
       componentOptions.computed![key] = function () {
         return this[reactiveInjectKey][fromKey] || defaultVal
       }
-      componentOptions.inject[reactiveInjectKey] = '__reactiveInject__'
+      componentOptions.inject[reactiveInjectKey] = reactiveInjectKey
     }
   })
 }

--- a/test/decorator.spec.ts
+++ b/test/decorator.spec.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import 'reflect-metadata'
-import { Component, Emit, Inject, Model, Prop, Provide, Watch, Mixins } from '../src/vue-property-decorator'
+import { Component, Emit, Inject, Model, Prop, Provide, Watch, Mixins, ProvideReactive, InjectReactive } from '../src/vue-property-decorator'
 import test from 'ava'
 
 test('@Emit decorator test', async t => {
@@ -106,6 +106,49 @@ test('@Inject decorator test', t => {
   t.is(grandChild.optional, 'default')
 })
 
+test('@InjectReactive decorator test', t => {
+  const s = Symbol()
+  @Component
+  class Parent extends Vue {
+    @ProvideReactive(s) baz = 'one';
+    @ProvideReactive() bar = 'two';
+  }
+
+  const parent = new Parent()
+
+  @Component
+  class Child extends Vue {
+    @InjectReactive(s) foo: string
+    @InjectReactive() bar: string
+    @InjectReactive({ from: 'optional', default: 'default' }) optional: string
+  }
+
+  const child = new Child({ parent })
+  t.is(child.foo, 'one')
+  t.is(child.bar, 'two')
+  t.is(child.optional, 'default')
+
+  parent.baz = 'qwerty'
+
+  t.is(child.foo, 'qwerty')
+
+  @Component
+  class GrandChild extends Vue {
+    @InjectReactive(s) foo: string
+    @InjectReactive() bar: string
+    @InjectReactive({ from: 'optional', default: 'default' }) optional: string
+  }
+
+  const grandChild = new GrandChild({ parent: child })
+  t.is(grandChild.foo, 'qwerty')
+  t.is(grandChild.bar, 'two')
+  t.is(grandChild.optional, 'default')
+
+  parent.bar = 'abcde'
+
+  t.is(grandChild.bar, 'abcde')
+})
+
 test('@Inject decroator test with @Prop decorator', t => {
   @Component({
     provide() {
@@ -194,6 +237,33 @@ test('@Provide decorator test', t => {
 
   t.is(child.one, 'one')
   t.is(child.two, 'two')
+})
+
+test('@ProvideReactive decorator test', t => {
+  @Component
+  class Parent extends Vue {
+    @ProvideReactive() one = 'one'
+    @ProvideReactive('two') twelve = 'two'
+  }
+
+  const parent = new Parent()
+
+  @Component
+  class Child extends Vue {
+    @InjectReactive() one: string
+    @InjectReactive() two: string
+  }
+
+  const child = new Child({ parent })
+
+  t.is(child.one, 'one')
+  t.is(child.two, 'two')
+
+  parent.one = 'three'
+  parent.twelve = 'four'
+
+  t.is(child.one, 'three')
+  t.is(child.two, 'four')
 })
 
 test('@Watch decorator test', t => {

--- a/test/decorator.spec.ts
+++ b/test/decorator.spec.ts
@@ -110,8 +110,8 @@ test('@InjectReactive decorator test', t => {
   const s = Symbol()
   @Component
   class Parent extends Vue {
-    @ProvideReactive(s) baz = 'one';
-    @ProvideReactive() bar = 'two';
+    @ProvideReactive(s) baz = 'one'
+    @ProvideReactive() bar = 'two'
   }
 
   const parent = new Parent()
@@ -149,7 +149,7 @@ test('@InjectReactive decorator test', t => {
   t.is(grandChild.bar, 'abcde')
 })
 
-test('@Inject decroator test with @Prop decorator', t => {
+test('@Inject decorator test with @Prop decorator', t => {
   @Component({
     provide() {
       return {
@@ -177,6 +177,38 @@ test('@Inject decroator test with @Prop decorator', t => {
   const child = new Child({ parent })
 
   t.is(child.myFoo, 'two')
+})
+
+test('@InjectReactive decorator test with @Prop decorator', t => {
+  @Component
+  class Parent extends Vue {
+    @ProvideReactive() bar = 'two'
+  }
+
+  const parent = new Parent()
+
+  @Component
+  class Child extends Vue {
+    @InjectReactive({ from: 'bar' }) reactive: string
+    @Inject({ from: 'bar' }) static: string
+
+    @Prop({
+      default() {
+        return this.static
+      }
+    })
+    myFoo: string
+  }
+
+  const child = new Child({ parent })
+
+  t.is(child.myFoo, 'two')
+
+  parent.bar = 'qwerty'
+
+  t.is(child.myFoo, 'two')
+  t.is(child.static, 'two')
+  t.is(child.reactive, 'qwerty')
 })
 
 test('@Model decorator test', t => {


### PR DESCRIPTION
Based on the request in #39 
I thought this would be a nice feature to have, so I took a crack at implementing it. If this is acceptable to merge, I'm happy to add documentation to the README!

_**One gotcha...**_
When using `@ProvideReactive` with `@Prop`, you must use `@Inject`—_not_ `@InjectReactive`—to use the injected property as a `default`... see the coverage for an example of this.