### PR TITLE
Add new decorator `Ref`

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,3 +322,38 @@ export default {
   }
 }
 ```
+
+### <a id="Ref"></a> `@Ref(refKey?: string)` decorator
+
+```ts
+import { Vue, Component, Ref } from 'vue-property-decorator'
+
+import AnotherComponent from '@/path/to/another-component.vue'
+
+@Component
+export default class YourComponent extends Vue {
+  @Ref() readonly anotherComponent!: AnotherComponent
+  @Ref('aButton') readonly button!: HTMLButtonElement
+}
+```
+
+is equivalent to
+
+```js
+export default {
+  computed() {
+    anotherComponent: {
+      cache: false,
+      get() {
+        return this.$refs.anotherComponent as AnotherComponent
+      }
+    },
+    button: {
+      cache: false,
+      get() {
+        return this.$refs.aButton as HTMLButtonElement
+      }
+    }
+  }
+}
+```

--- a/src/vue-property-decorator.ts
+++ b/src/vue-property-decorator.ts
@@ -228,6 +228,23 @@ export function Emit(event?: string): MethodDecorator {
   }
 }
 
+/**
+ * decorator of a ref prop
+ * @param refKey the ref key defined in template
+ */
+export function Ref(refKey?: string) {
+  return createDecorator((options, key) => {
+    options.computed = options.computed || {};
+    options.computed[key] = {
+      cache: false,
+      get(this: Vue) {
+        return this.$refs[refKey || key];
+      },
+    };
+  });
+}
+
+
 function isPromise(obj: any): obj is Promise<any> {
   return obj instanceof Promise || (obj && typeof obj.then === 'function')
 }

--- a/test/decorator.spec.ts
+++ b/test/decorator.spec.ts
@@ -1,7 +1,19 @@
 import Vue from 'vue'
 import 'reflect-metadata'
-import { Component, Emit, Inject, Model, Prop, Provide, Watch, Mixins } from '../src/vue-property-decorator'
-import { Component, Emit, Inject, InjectReactive, Model, Prop, PropSync, Provide, ProvideReactive, Watch, Mixins } from '../src/vue-property-decorator'
+import {
+  Component,
+  Emit,
+  Inject,
+  Model,
+  Prop,
+  PropSync,
+  Provide,
+  Watch,
+  Mixins,
+  ProvideReactive,
+  InjectReactive,
+  Ref
+} from '../src/vue-property-decorator'
 import test from 'ava'
 
 test('@Emit decorator test', async t => {
@@ -385,6 +397,29 @@ test('@Watch decorator test', t => {
 
   t.is(method1, 1, 'method1 should be 1')
   t.is(method2, 2, 'method2 should be 2')
+})
+
+test('@Ref decorator test', t => {
+  @Component
+  class Test extends Vue {
+    @Ref() prop1: any;
+    @Ref('ref2') prop2: any;
+  }
+
+  const test = new Test()
+  const { $options } = test
+  const computed = $options.computed as any
+
+  test.$refs.prop1 = 'ref1' as any
+  test.$refs.ref2 = 'ref2' as any
+
+  t.is(computed.prop1.cache, false)
+  t.is(typeof computed.prop1.get, 'function')
+  t.is(test.prop1, 'ref1')
+
+  t.is(computed.prop2.cache, false)
+  t.is(typeof computed.prop2.get, 'function')
+  t.is(test.prop2, 'ref2')
 })
 
 test('Mixins helper test', t => {


### PR DESCRIPTION
Inspired by https://angular.io/api/core/ViewChild.

[Vue#$refs](https://vuejs.org/v2/api/#vm-refs) is generally typed as `{ [key: string]: Vue | Element | Vue[] | Element[] }`, and using it in TypeScript often requires a type cast. The proposed decorator tries to simplify its usage.