### PR TITLE
Update prop obligatory and type definition in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ import { Vue, Component, Prop } from 'vue-property-decorator'
 
 @Component
 export default class YourComponent extends Vue {
-  @Prop(Number) readonly propA!: number | undefined
+  @Prop(Number) readonly propA: number | undefined
   @Prop({ default: 'default value' }) readonly propB!: string
-  @Prop([String, Boolean]) readonly propC!: string | boolean | undefined
+  @Prop([String, Boolean]) readonly propC: string | boolean | undefined
 }
 ```
 


### PR DESCRIPTION
Hi,
I just started using vue / vue-property-decorator / typescript so it is possible I dont fully understand some important details but when I was reading readme I think I noticed a mistake. In @Prop usage example `propA` and `propC` are marked as required by having `!` so undefined type should not be allowed on those props. I prepared a PR so if indeed this is a mistake in readme lets fix it.

Cheers!