### PR TITLE
Proposal: @WatchMatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ There are 7 decorators and 1 function (Mixin):
 - [`@Provide`](#Provide)
 - [`@Model`](#Model)
 - [`@Watch`](#Watch)
+- [`@WatchMatch`](#WatchMatch)
 - [`@Inject`](#Provide)
 - [`@Provide`](#Provide)
 - [`@Emit`](#Emit)
@@ -190,6 +191,77 @@ export default {
   }
 }
 ```
+
+### <a id="WatchMatch"></a> `@WatchMatch(options: WatchOptions = {})` decorator
+
+Similar to [@Watch](#Wathc). It matches the property name in **camel case** using the pattern `/watch(\w+)`, extracs property name and adds a watch handler. As the name suggests, you can only use this decorator to add only **one** watch handler to **one** property.
+
+```ts
+import { Vue, Component, Watch, WatchMatch } from 'vue-property-decorator'
+
+@Component
+export default class YourComponent extends Vue {
+  child1: string;
+  child2: string;
+  child3: string;
+  
+  @WatchMatch
+  watchChild1(val: string, oldVal: string) {}
+
+  @WatchMatch({ immediate: true, deep: true })
+  watchChild2(val: string, oldVal: string) {}
+  
+  // @Watch and @WatchMatch
+  @Watch('child2')
+  @WatchMatch 
+  watchChild3(val: string, oldVal: string) {
+    // execute this function whether child2 or child3 have changed
+  }
+  
+}
+```
+
+is equivalent to
+
+```ts
+export default {
+  watch: {
+    child1: [
+      {
+        handler: 'watchChild1',
+        immediate: false,
+        deep: false
+      }
+    ],
+    child2: [
+      {
+        handler: 'watchChild2',
+        immediate: true,
+        deep: true
+      },
+      {
+        handler: 'watchChild3',
+        immediate: false,
+        deep: false
+      }
+    ],
+    child3: [
+      {
+        handler: 'watchChild3',
+        immediate: false,
+        deep: false
+      }
+    ]
+  },
+  methods: {
+    watchChild1(val, oldVal) {},
+    watchChild2(val, oldVal) {},
+    watchChild3(val, oldVal) {}
+  }
+}
+```
+
+
 
 ### <a id="Provide"></a> `@Provide(key?: string | symbol)` / `@Inject(options?: { from?: InjectKey, default?: any } | InjectKey)` decorator
 

--- a/src/vue-property-decorator.ts
+++ b/src/vue-property-decorator.ts
@@ -205,8 +205,39 @@ export function PropSync(
  */
 export function Watch(path: string, options: WatchOptions = {}) {
   const { deep = false, immediate = false } = options
-
   return createDecorator((componentOptions, handler) => {
+    if (typeof componentOptions.watch !== 'object') {
+      componentOptions.watch = Object.create(null)
+    }
+
+    const watch: any = componentOptions.watch
+
+    if (typeof watch[path] === 'object' && !Array.isArray(watch[path])) {
+      watch[path] = [watch[path]]
+    } else if (typeof watch[path] === 'undefined') {
+      watch[path] = []
+    }
+
+    watch[path].push({ handler, deep, immediate })
+  })
+}
+
+/**
+ * decorator of a watch function. It matches property name from function name
+ * using regex /watch(w+)/
+ * E.g. "watchIsTest" creates a watcher for a component property called "isTest"
+ * @param  WatchOptions
+ * @return MethodDecorator
+ */
+export function WatchMatch(options: WatchOptions = {}) {
+  const { deep = false, immediate = false } = options
+  return createDecorator((componentOptions, handler) => {
+    let pathMatch = handler.match(/watch(\w+)/)
+    if (!pathMatch) return
+
+    let path = pathMatch[1] // extract path
+    path = path[0].toLowerCase() + path.slice(1) // camel case
+
     if (typeof componentOptions.watch !== 'object') {
       componentOptions.watch = Object.create(null)
     }

--- a/tests/WatchMatch.spec.ts
+++ b/tests/WatchMatch.spec.ts
@@ -1,0 +1,58 @@
+import Vue from 'vue'
+import { WatchMatch, Watch, Component } from '../src/vue-property-decorator'
+
+describe(WatchMatch, () => {
+
+  const method1 = jest.fn()
+  const method2 = jest.fn()
+
+  @Component
+  class Test extends Vue {
+    expressionA: boolean = false
+    expressionB = 0
+
+    @Watch('expressionB')
+    @WatchMatch()
+    watchExpressionA() {
+      method1()
+    }
+
+    @WatchMatch({ immediate: true })
+    watchExpressionB() {
+      method2()
+    }
+
+    @WatchMatch()
+    noMatch() {
+      method2();
+    }
+  }
+
+  const component = new Test()
+
+  beforeAll(() => {
+    component.expressionA = true
+    component.expressionB = 1;
+
+    jest.clearAllMocks();
+  })
+
+  test('defines watch options', () => {
+    const watch = component.$options.watch as any
+    expect(watch['expressionB']).toHaveLength(2)
+
+    expect(watch['expressionB'][0].handler).toBe('watchExpressionA')
+    expect(watch['expressionB'][1].handler).toBe('watchExpressionB')
+    expect(watch['expressionB'][1].immediate).toBe(true)
+  })
+
+  test('watch handlers are called', () => {
+    expect(method1).toHaveBeenCalledTimes(2)
+    expect(method2).toHaveBeenCalled()
+  })
+
+  test('does not add watcher if method name does not match', () => {
+    const watch = component.$options.watch as any
+    expect(watch['noMatch']).toBeUndefined()
+  })
+})


### PR DESCRIPTION
This is just a little trick to avoid repetitive strings.
For common users it's normal to have the following code
```ts
property: number = 0;
@Watch('property')
onPropertyChanged() {}
```
With this proposal that can be changed to
```ts
property: number = 0;
@WatchMatch
watchProperty() {}
```

### Motivation
I always follow DRY principles in every aspect, setting the path param to match the property name ends up being repetitive when I have individual watchers for many properties.
I know this could be solved using a constant string with the property name and making use of the key signature on TS, but this seems cleaner to me.