### PR TITLE
Vue typing issue solved

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
     "reflect-metadata": "^0.1.13",
     "rollup": "^1.15.6",
     "ts-jest": "^24.0.2",
-    "typescript": "^3.5.2"
+    "typescript": "^3.5.2",
+    "vue": "^2.6.10"
   },
   "typings": "./lib/vue-property-decorator.d.ts",
   "dependencies": {
-    "vue": "^2.6.10",
     "vue-class-component": "^7.0.1"
   },
   "repository": {


### PR DESCRIPTION
When this package is used in a project that has a modified Vue type (like using i18n or so), the decorators of this project give error because the output type is not matching (it does pick the vue package installed inside the package folder).

With this change the decorator inherits the type from the project instead of the local one and thus not giving any error.

This solution comes from what the official vue-class-component package is doing.
https://github.com/vuejs/vue-class-component/blob/master/package.json#L65