### PR TITLE
Proposal: @ModelSync

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ There are several decorators and 1 function (Mixin):
 - [`@Prop`](#Prop)
 - [`@PropSync`](#PropSync)
 - [`@Model`](#Model)
+- [`@ModelSync](#ModelSync)
 - [`@Watch`](#Watch)
 - [`@Provide`](#Provide)
 - [`@Inject`](#Provide)
@@ -141,6 +142,45 @@ export default {
 ```
 
 `@Model` property can also set `type` property from its type definition via `reflect-metadata` .
+
+### <a id="ModelSync"></a> `@ModelSync(propName: string, event?: string, options: (PropOptions | Constructor[] | Constructor) = {})` decorator
+
+```ts
+import { Vue, Component, ModelSync } from 'vue-property-decorator'
+
+@Component
+export default class YourComponent extends Vue {
+  @ModelSync('checked', 'change', { type: Boolean }) readonly checkedValue!: boolean
+}
+```
+
+is equivalent to
+
+```js
+export default {
+  model: {
+    prop: 'checked',
+    event: 'change'
+  },
+  props: {
+    checked: {
+      type: Boolean
+    }
+  },
+  computed: {
+    checkedValue: {
+      get() {
+        return this.checked
+      },
+      set(value) {
+        this.$emit('change', value)
+      }
+    }
+  }
+}
+```
+
+`@ModelSync` property can also set `type` property from its type definition via `reflect-metadata` .
 
 ### <a id="Watch"></a> `@Watch(path: string, options: WatchOptions = {})` decorator
 

--- a/src/vue-property-decorator.ts
+++ b/src/vue-property-decorator.ts
@@ -152,6 +152,38 @@ export function Model(
 }
 
 /**
+ * decorator of synced model and prop
+ * @param propName the name to interface with from outside, must be different from decorated property
+ * @param  event event name
+ * @param options options
+ * @return PropertyDecorator
+ */
+export function ModelSync(
+  propName: string,
+  event?: string,
+  options: PropOptions | Constructor[] | Constructor = {},
+) {
+  return (target: Vue, key: string) => {
+    applyMetadata(options, target, key)
+    createDecorator((componentOptions, k) => {
+      ;(componentOptions.props || ((componentOptions.props = {}) as any))[
+        propName
+      ] = options
+      componentOptions.model = { prop: propName, event: event || k }
+      ;(componentOptions.computed || (componentOptions.computed = {}))[k] = {
+        get() {
+          return (this as any)[propName]
+        },
+        set(value) {
+          // @ts-ignore
+          this.$emit(event, value)
+        },
+      }
+    })(target, key)
+  }
+}
+
+/**
  * decorator of a prop
  * @param  options the options for the prop
  * @return PropertyDecorator | void

--- a/tests/ModelSync.spec.ts
+++ b/tests/ModelSync.spec.ts
@@ -1,0 +1,52 @@
+import Vue from 'vue'
+import 'reflect-metadata'
+import { ModelSync, Component } from '../src/vue-property-decorator'
+
+describe(ModelSync, () => {
+  const eventName = 'change'
+  const propertyName = 'checked'
+  const accessorName = 'chackedValue'
+  @Component
+  class TestComponent extends Vue {
+    @ModelSync(propertyName, eventName, Boolean) [accessorName]!: boolean
+
+    changeChecked(newValue: boolean) {
+      this[accessorName] = newValue
+    }
+  }
+
+  const initialValue = false
+  const component = new TestComponent({ propsData: { [propertyName]: initialValue } })
+  const mockFunction = jest.fn()
+  component.$emit = mockFunction
+
+  test('define model option correctly', () => {
+    expect(component.$options.model).toEqual({ prop: propertyName, event: eventName })
+  })
+
+  test('define props option correctly', () => {
+    const props = (component.$options.props as any) as Record<string, any>
+    expect(props![propertyName]).toEqual({ type: Boolean })
+  })
+
+  test('component recieves prop', () => {
+    expect(component[accessorName]).toBe(initialValue)
+  })
+
+  describe('when props has been changed', () => {
+    const newValue = true
+    component.changeChecked(newValue)
+
+    test('calls $emit method', () => {
+      expect(mockFunction).toHaveBeenCalled()
+    })
+
+    test('emits event with event name', () => {
+      expect(mockFunction.mock.calls[0][0]).toBe(eventName)
+    })
+
+    test('emits event with new value', () => {
+      expect(mockFunction.mock.calls[0][1]).toBe(newValue)
+    })
+  })
+})


### PR DESCRIPTION
@kaorun343 

inspired from https://github.com/kaorun343/vue-property-decorator/issues/86, https://github.com/kaorun343/vue-property-decorator/pull/204

### <a id="ModelSync"></a> `@ModelSync(propName: string, event?: string, options: (PropOptions | Constructor[] | Constructor) = {})` decorator

```ts
import { Vue, Component, ModelSync } from 'vue-property-decorator'

@Component
export default class YourComponent extends Vue {
  @ModelSync('checked', 'change', { type: Boolean }) readonly checkedValue!: boolean
}
```

is equivalent to

```js
export default {
  model: {
    prop: 'checked',
    event: 'change'
  },
  props: {
    checked: {
      type: Boolean
    }
  },
  computed: {
    checkedValue: {
      get() {
        return this.checked
      },
      set(value) {
        this.$emit('change', value)
      }
    }
  }
}
```

`@ModelSync` property can also set `type` property from its type definition via `reflect-metadata` .

## Motivation
Don't need to write the accessor for model, like as `@PropSync`