### PR TITLE
Fix @ProvideReactive() inheritance issue

### DIFF
--- a/src/vue-property-decorator.ts
+++ b/src/vue-property-decorator.ts
@@ -100,7 +100,7 @@ export function ProvideReactive(key?: string | symbol) {
             : original
         rv = Object.create(rv || null)
         // set reactive services (propagates previous services if necessary)
-        rv[reactiveInjectKey] = rv[reactiveInjectKey] || this[reactiveInjectKey] || {}
+        rv[reactiveInjectKey] = this[reactiveInjectKey] || {}
         for (let i in provide.managedReactive) {
           rv[provide.managedReactive[i]] = this[i] // Duplicates the behavior of `@Provide`
           Object.defineProperty(rv[reactiveInjectKey], provide.managedReactive[i], {

--- a/tests/Provide.spec.ts
+++ b/tests/Provide.spec.ts
@@ -22,6 +22,31 @@ describe(Provide, () => {
     })
   })
 
+  describe('does not override parent dependencies', () => {
+    @Component
+    class ParentComponent extends Vue {
+      @Provide() root = 'root'
+    }
+    @Component
+    class NodeComponent extends Vue {
+      @Provide() node = 'node'
+    }
+    @Component
+    class ChildComponent extends Vue {
+      @Inject() root!: string
+      @Inject() node!: string
+    }
+
+    const parent = new ParentComponent()
+    const node = new NodeComponent({ parent })
+    const component = new ChildComponent({ parent: node  })
+
+    test('provides value', () => {
+      expect(component.node).toBe('node')
+      expect(component.root).toBe('root')
+    })
+  })
+
   describe('when key is given', () => {
     const key = 'KEY'
     const value = 'VALUE'

--- a/tests/ProvideReactive.spec.ts
+++ b/tests/ProvideReactive.spec.ts
@@ -81,6 +81,38 @@ describe(ProvideReactive, () => {
   })
 
 
+  describe('does not override parent reactive dependencies', () => {
+    @Component
+    class ParentComponent extends Vue {
+      @ProvideReactive() root = 'root'
+    }
+    @Component
+    class NodeComponent extends Vue {
+      @ProvideReactive() node = 'node'
+    }
+    @Component
+    class ChildComponent extends Vue {
+      @InjectReactive() root!: string
+      @InjectReactive() node!: string
+    }
+
+    const parent = new ParentComponent()
+    const node = new NodeComponent({ parent })
+    const component = new ChildComponent({ parent: node  })
+
+    test('provides value', () => {
+      expect(component.node).toBe('node')
+      expect(component.root).toBe('root') // <== this one used to throw
+
+      // check that they update correctly
+      parent.root = 'new root'
+      node.node = 'new node'
+      expect(component.root).toBe('new root')
+      expect(component.node).toBe('new node')
+    })
+  })
+
+
   describe('when key is given', () => {
     const key = 'KEY'
     const value = 'VALUE'


### PR DESCRIPTION
See the new test in ProvideReactive.spec.ts, but long story short: Using `@ProvideReactive()` in a child component overrides all parent dependencies provided using the same method.

For instance, when:
- Component A provides 'X'
- Component B, child of A, provides 'Y'
- Component C uses both 'X' & 'Y'

Then 'Y' is injected, but not 'X'.

This commit fixes it (& adds some test to check that this scenario works for both `@Provide` and `@ProvideReactive`