### PR TITLE
Yarn 2: Add vue as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
   "dependencies": {
     "vue-class-component": "^7.1.0"
   },
+  "peerDependencies": {
+    "vue": "*"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kaorun343/vue-property-decorator.git"


### PR DESCRIPTION
This is needed for Yarn 2 compatibility with Plug'n'Play.