### PR TITLE
Fix Emit Decorator with multiple arguments

### DIFF
--- a/src/vue-property-decorator.ts
+++ b/src/vue-property-decorator.ts
@@ -274,10 +274,16 @@ export function Emit(event?: string) {
           } else if (args.length === 1) {
             this.$emit(emitName, args[0])
           } else {
-            this.$emit(emitName, args)
+            this.$emit(emitName, ...args)
           }
         } else {
-          this.$emit(emitName, returnValue)
+          if (args.length === 0) {
+            this.$emit(emitName, returnValue)
+          } else if (args.length === 1) {
+            this.$emit(emitName, returnValue, args[0])
+          } else {
+            this.$emit(emitName, returnValue, ...args)
+          }
         }
       }
 

--- a/tests/Emit.spec.ts
+++ b/tests/Emit.spec.ts
@@ -61,6 +61,77 @@ describe(Emit, () => {
       expect(mockFn.mock.calls[0][1]).toBe(value)
     })
   })
+  
+  describe('when multiple arguments is given', () => {
+    @Component
+    class ChildComponent extends Vue {
+      count = 0
+
+      @Emit() increment(n1: number, n2: number) {
+        this.count += n1 + n2 
+      }
+    }
+
+    const child = new ChildComponent()
+    const mockFn = jest.fn()
+    child.$emit = mockFn
+
+    const value1 = 30
+    const value2 = 40
+
+    beforeAll(() => {
+      child.increment(value1, value2)
+    })
+
+    test('call $emit method', () => {
+      expect(mockFn).toHaveBeenCalled()
+    })
+
+    test('emit event with method name', () => {
+      expect(mockFn.mock.calls[0][0]).toBe('increment')
+    })
+
+    test('emit event with multiple arguments', () => {
+      expect(mockFn.mock.calls[0][1]).toBe(value1)
+      expect(mockFn.mock.calls[0][2]).toBe(value2)
+    })
+  })
+
+  describe('when the value is returned and multiple arguments is given', () => {
+    @Component
+    class ChildComponent extends Vue {
+      count = 0
+
+      @Emit() increment(n1: number, n2: number) {
+        return n1 + n2;
+      }
+    }
+
+    const child = new ChildComponent()
+    const mockFn = jest.fn()
+    child.$emit = mockFn
+
+    const value1 = 30
+    const value2 = 40
+
+    beforeAll(() => {
+      child.increment(value1, value2)
+    })
+
+    test('call $emit method', () => {
+      expect(mockFn).toHaveBeenCalled()
+    })
+
+    test('emit event with method name', () => {
+      expect(mockFn.mock.calls[0][0]).toBe('increment')
+    })
+
+    test('emit event with multiple arguments', () => {
+      expect(mockFn.mock.calls[0][1]).toBe(value1 + value2)
+      expect(mockFn.mock.calls[0][2]).toBe(value1)
+      expect(mockFn.mock.calls[0][3]).toBe(value2)
+    })
+  })
 
   describe('when promise has been returned', () => {
     const value = 10


### PR DESCRIPTION
When using Emit with multiple arguments, it will not work properly.
Maybe because the arguments are passed as an array

https://github.com/kaorun343/vue-property-decorator/commit/b9f0ba86b1b0a58164a19aba07ae82836a6c57a9#diff-a542f5e3653e6b2d1bd03489368849b9R269