### PR TITLE
Follow up to PR #299: Provide/Inject reactive fixes

### DIFF
--- a/src/vue-property-decorator.ts
+++ b/src/vue-property-decorator.ts
@@ -66,22 +66,20 @@ function produceProvide(original: any) {
     let rv = typeof original === 'function' ? original.call(this) : original
     rv = Object.create(rv || null)
     // set reactive services (propagates previous services if necessary)
-    rv[reactiveInjectKey] = this[reactiveInjectKey] || {}
+    rv[reactiveInjectKey] = Object.create(this[reactiveInjectKey] || {})
     for (let i in provide.managed) {
       rv[provide.managed[i]] = this[i]
     }
     for (let i in provide.managedReactive) {
-      rv[provide.managedReactive[i]] = this[i] // Duplicates the behavior of `@Provide`
-      if (!rv[reactiveInjectKey].hasOwnProperty(provide.managedReactive[i])) {
+        rv[provide.managedReactive[i]] = this[i] // Duplicates the behavior of `@Provide`
         Object.defineProperty(
-          rv[reactiveInjectKey],
-          provide.managedReactive[i],
-          {
+            rv[reactiveInjectKey],
+            provide.managedReactive[i],
+            {
             enumerable: true,
             get: () => this[i],
-          },
+            },
         )
-      }
     }
     return rv
   }

--- a/src/vue-property-decorator.ts
+++ b/src/vue-property-decorator.ts
@@ -3,7 +3,7 @@
 'use strict'
 import Vue, { PropOptions, WatchOptions } from 'vue'
 import Component, { createDecorator, mixins } from 'vue-class-component'
-import { InjectKey } from 'vue/types/options'
+import { InjectKey, ComponentOptions } from 'vue/types/options'
 
 export type Constructor = {
   new (...args: any[]): any
@@ -97,6 +97,17 @@ function needToProduceProvide(original: any) {
   )
 }
 
+function inheritInjected(componentOptions: ComponentOptions<Vue>) {
+    // inject parent reactive services (if any)
+    if (!Array.isArray(componentOptions.inject)) {
+        componentOptions.inject = componentOptions.inject || {}
+        componentOptions.inject[reactiveInjectKey] = {
+          from: reactiveInjectKey,
+          default: {},
+        }
+    }
+}
+
 /**
  * decorator of a provide
  * @param key key
@@ -105,6 +116,7 @@ function needToProduceProvide(original: any) {
 export function Provide(key?: string | symbol) {
   return createDecorator((componentOptions, k) => {
     let provide: any = componentOptions.provide
+    inheritInjected(componentOptions)
     if (needToProduceProvide(provide)) {
       provide = componentOptions.provide = produceProvide(provide)
     }
@@ -120,14 +132,7 @@ export function Provide(key?: string | symbol) {
 export function ProvideReactive(key?: string | symbol) {
   return createDecorator((componentOptions, k) => {
     let provide: any = componentOptions.provide
-    // inject parent reactive services (if any)
-    if (!Array.isArray(componentOptions.inject)) {
-      componentOptions.inject = componentOptions.inject || {}
-      componentOptions.inject[reactiveInjectKey] = {
-        from: reactiveInjectKey,
-        default: {},
-      }
-    }
+    inheritInjected(componentOptions)
     if (needToProduceProvide(provide)) {
       provide = componentOptions.provide = produceProvide(provide)
     }


### PR DESCRIPTION
A couple more issues have been discovered after my PR #299 was integrated into the 8.4.1 release:

1. If a component in the middle of the hierarchy does not get injections but participates as a provider, the chain of reactive provides would be broken.
2. Children components cannot overwrite provided reactive services of the same name, as is possible with regular provided components. This fixes that making them behave in a equivalent form.