### PR TITLE
Configureable provide reactive properties.

### DIFF
--- a/src/vue-property-decorator.ts
+++ b/src/vue-property-decorator.ts
@@ -77,6 +77,7 @@ function produceProvide(original: any) {
         provide.managedReactive[i],
         {
         enumerable: true,
+        configurable: true,
         get: () => this[i],
         },
       )


### PR DESCRIPTION
## The issue
When producing a provide function for ProvideReactive the properties are defined as not configureable. This causes a TypeError when unmounting and mounting again a component that uses `@ProvideReactive` because the provide function is called again and tries to redefine a non configureable property.

Referenced here:
https://github.com/kaorun343/vue-property-decorator/issues/313#issuecomment-641834471

## Solution
make it configurable 