### PR TITLE
hofix/types

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "vue": "^2.6.10",
     "vue-class-component": "^7.2.3"
   },
-  "typings": "./lib/vue-property-decorator.d.ts",
+  "typings": "./lib/index.d.ts",
   "dependencies": {},
   "peerDependencies": {
     "vue": "*",


### PR DESCRIPTION
When the file vue-property-decorator was renamed to index the types declarations name changed too!

The problem: 
![image](https://user-images.githubusercontent.com/33099123/99829318-ebda9380-2b3a-11eb-913d-f92c2cd45c03.png)

The type definition file
![image](https://user-images.githubusercontent.com/33099123/99829407-07de3500-2b3b-11eb-8c56-8780a89834f7.png)

The solution. Change to index.d.ts this part of code in **package.json**
```json
"typings": "./lib/vue-property-decorator.d.ts",
```
