### PR TITLE
Fix README typo @Option -> @Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ There are several decorators:
 
 Also, these are re-exported from `vue-class-component`
 
-- `@Option`
+- `@Options`
 - `mixins`
 - `Vue`
 


### PR DESCRIPTION
Because that's what's being exported in

https://github.com/kaorun343/vue-property-decorator/blob/2268e895facd3d5e4f912be83a00857fe07a8b64/src/index.ts#L2